### PR TITLE
docs(readme): updated instructions on provider usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Declare it as dependency in your app:
 angular.module('myApp', ['pascalprecht.github-adapter']);
 ```
 
-Use the `$githubProvider` to configure the service:
+Use the `$github` provider to configure the service:
 
 ```js
-angular.module('myApp').config(function ($githubProvider) {
-  $githubProvider.username('YOUR_USERNAME');
-  $githubProvider.password('YOUR_PASSWORD');
-  $githubProvider.authType('basic');
+angular.module('myApp').config(function ($github) {
+  $github.username('YOUR_USERNAME');
+  $github.password('YOUR_PASSWORD');
+  $github.authType('basic');
 });
 ```
 


### PR DESCRIPTION
As stated in the second point in the feedback from #2, there is an error if you try to use `$githubProvider` so this changes that in the README to `$github` instead.
