### PR TITLE
return a promise from listPulls function

### DIFF
--- a/src/githubRepository.js
+++ b/src/githubRepository.js
@@ -297,6 +297,7 @@ angular.module('pascalprecht.github-adapter')
             deferred.resolve(pulls);
           }
         });
+        return deferred.promise;
       },
 
       getPull: function (number) {


### PR DESCRIPTION
Thanks for the module! Looks like the listPulls function in githubRepository.js was missing a return for the promise. I added it and it seems to be working now. I spot-checked the rest of the functions for any missing returns just in case. That seemed to be the only one.

Thanks!
